### PR TITLE
FIX: Prevent decimalised token staking amounts

### DIFF
--- a/packages/react-app/src/components/PoolCard.js
+++ b/packages/react-app/src/components/PoolCard.js
@@ -556,7 +556,7 @@ export default function PoolCard({
                 padding="12px"
                 bg="#fff"
                 value={depositAmountToken}
-                onChange={(e) => {setDepositAmountToken(e.target.value)}}
+                onChange={(e) => {setDepositAmountToken(parseInt(e.target.value) || 0)}}
               />
               <ItemH>
                 <ButtonAlt


### PR DESCRIPTION
This is a small but important fix to prevent decimalised token amounts in both pools short term.

There is a much larger fix required, ie using a native number input and possibly additional on screen documentation, which i would be happy to attempt given a team lead proposal on what and how this area could be improved.

In the short term this would at least prevent people loosing gas fees.